### PR TITLE
update analytics version for next pod release

### DIFF
--- a/Segment-Branch.podspec
+++ b/Segment-Branch.podspec
@@ -23,6 +23,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes/**/*'
 
-  s.dependency 'Analytics', '~> 3.0.1-alpha'
+  s.dependency 'Analytics', '~> 3.0.2-alpha'
   s.dependency 'Branch'
 end


### PR DESCRIPTION
@Sarkar @aaustin next release we cut of this pod, we should increment the analytics version number. The newer version should no longer throw warnings due to deprecated Segment SDK methods.
