### PR TITLE
Make the interfaces more Swift friendly

### DIFF
--- a/Pod/Classes/BNCBranchIntegration.h
+++ b/Pod/Classes/BNCBranchIntegration.h
@@ -1,10 +1,14 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegration.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface BNCBranchIntegration : NSObject<SEGIntegration>
 
 @property(nonatomic, strong) NSDictionary *settings;
 
-- (id)initWithSettings:(NSDictionary *)settings;
+- (instancetype)initWithSettings:(NSDictionary *)settings NS_SWIFT_NAME(init(setttings:));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/BNCBranchIntegration.m
+++ b/Pod/Classes/BNCBranchIntegration.m
@@ -4,7 +4,7 @@
 
 @implementation BNCBranchIntegration
 
-- (id)initWithSettings:(NSDictionary *)settings
+- (instancetype)initWithSettings:(NSDictionary *)settings
 {
     if (self = [super init]) {
         self.settings = settings;

--- a/Pod/Classes/BNCBranchIntegrationFactory.h
+++ b/Pod/Classes/BNCBranchIntegrationFactory.h
@@ -1,8 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegrationFactory.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface BNCBranchIntegrationFactory : NSObject<SEGIntegrationFactory>
 
-+ (id)instance;
++ (instancetype)instance;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/BNCBranchIntegrationFactory.m
+++ b/Pod/Classes/BNCBranchIntegrationFactory.m
@@ -3,7 +3,7 @@
 
 @implementation BNCBranchIntegrationFactory
 
-+ (id)instance
++ (instancetype)instance
 {
     static dispatch_once_t once;
     static BNCBranchIntegrationFactory *sharedInstance;
@@ -13,7 +13,7 @@
     return sharedInstance;
 }
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     return self;


### PR DESCRIPTION
`BNCBranchIntegrationFactory.instance()` returns `Any!` which requeries a force cast to `SEGIntegrationFactory`.
This simple changes will avoid unnecessary casts.